### PR TITLE
Add verbes pronominaux group

### DIFF
--- a/index.html
+++ b/index.html
@@ -599,6 +599,10 @@
           verbs: ['se laver', "s'habiller"],
         },
         {
+          title: 'Verbes pronominaux',
+          verbs: ["s'amuser", 'se dépêcher', 'se promener', 'se souvenir'],
+        },
+        {
           title: 'Efforts et réussite',
           verbs: ['attendre', 'commencer', 'réussir', 'perdre', 'gagner'],
         },
@@ -941,6 +945,34 @@
           futur: { je: "m'habillerai", tu: "t'habilleras", il: "s'habillera", nous: 'nous habillerons', vous: 'vous habillerez', ils: "s'habilleront" },
           passe_compose: { je: "me suis habillé", tu: "t'es habillé", il: "s'est habillé", nous: 'nous sommes habillés', vous: 'vous êtes habillés', ils: "se sont habillés" },
           conditionnel: { je: "m'habillerais", tu: "t'habillerais", il: "s'habillerait", nous: 'nous habillerions', vous: 'vous habilleriez', ils: "s'habilleraient" },
+        },
+        "s'amuser": {
+          present: { je: "m'amuse", tu: "t'amuses", il: "s'amuse", nous: 'nous amusons', vous: 'vous amusez', ils: "s'amusent" },
+          imparfait: { je: "m'amusais", tu: "t'amusais", il: "s'amusait", nous: 'nous amusions', vous: 'vous amusiez', ils: "s'amusaient" },
+          futur: { je: "m'amuserai", tu: "t'amuseras", il: "s'amusera", nous: 'nous amuserons', vous: 'vous amuserez', ils: "s'amuseront" },
+          passe_compose: { je: "me suis amusé", tu: "t'es amusé", il: "s'est amusé", nous: 'nous sommes amusés', vous: 'vous êtes amusés', ils: "se sont amusés" },
+          conditionnel: { je: "m'amuserais", tu: "t'amuserais", il: "s'amuserait", nous: 'nous amuserions', vous: 'vous amuseriez', ils: "s'amuseraient" },
+        },
+        'se dépêcher': {
+          present: { je: 'me dépêche', tu: 'te dépêches', il: 'se dépêche', nous: 'nous dépêchons', vous: 'vous dépêchez', ils: 'se dépêchent' },
+          imparfait: { je: 'me dépêchais', tu: 'te dépêchais', il: 'se dépêchait', nous: 'nous dépêchions', vous: 'vous dépêchiez', ils: 'se dépêchaient' },
+          futur: { je: 'me dépêcherai', tu: 'te dépêcheras', il: 'se dépêchera', nous: 'nous dépêcherons', vous: 'vous dépêcherez', ils: 'se dépêcheront' },
+          passe_compose: { je: 'me suis dépêché', tu: "t'es dépêché", il: "s'est dépêché", nous: 'nous sommes dépêchés', vous: 'vous êtes dépêchés', ils: 'se sont dépêchés' },
+          conditionnel: { je: 'me dépêcherais', tu: 'te dépêcherais', il: 'se dépêcherait', nous: 'nous dépêcherions', vous: 'vous dépêcheriez', ils: 'se dépêcheraient' },
+        },
+        'se promener': {
+          present: { je: 'me promène', tu: 'te promènes', il: 'se promène', nous: 'nous promenons', vous: 'vous promenez', ils: 'se promènent' },
+          imparfait: { je: 'me promenais', tu: 'te promenais', il: 'se promenait', nous: 'nous promenions', vous: 'vous promeniez', ils: 'se promenaient' },
+          futur: { je: 'me promènerai', tu: 'te promèneras', il: 'se promènera', nous: 'nous promènerons', vous: 'vous promènerez', ils: 'se promèneront' },
+          passe_compose: { je: 'me suis promené', tu: "t'es promené", il: "s'est promené", nous: 'nous sommes promenés', vous: 'vous êtes promenés', ils: 'se sont promenés' },
+          conditionnel: { je: 'me promènerais', tu: 'te promènerais', il: 'se promènerait', nous: 'nous promènerions', vous: 'vous promèneriez', ils: 'se promèneraient' },
+        },
+        'se souvenir': {
+          present: { je: 'me souviens', tu: 'te souviens', il: 'se souvient', nous: 'nous souvenons', vous: 'vous souvenez', ils: 'se souviennent' },
+          imparfait: { je: 'me souvenais', tu: 'te souvenais', il: 'se souvenait', nous: 'nous souvenions', vous: 'vous souveniez', ils: 'se souvenaient' },
+          futur: { je: 'me souviendrai', tu: 'te souviendras', il: 'se souviendra', nous: 'nous souviendrons', vous: 'vous souviendrez', ils: 'se souviendront' },
+          passe_compose: { je: 'me suis souvenu', tu: "t'es souvenu", il: "s'est souvenu", nous: 'nous sommes souvenus', vous: 'vous êtes souvenus', ils: 'se sont souvenus' },
+          conditionnel: { je: 'me souviendrais', tu: 'te souviendrais', il: 'se souviendrait', nous: 'nous souviendrions', vous: 'vous souviendriez', ils: 'se souviendraient' },
         },
         'attendre': {
           present: { je: 'attends', tu: 'attends', il: 'attend', nous: 'attendons', vous: 'attendez', ils: 'attendent' },


### PR DESCRIPTION
## Summary
- add a new "Verbes pronominaux" selection group with four reflexive verbs
- provide full conjugation tables for each newly added pronominal verb

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc6fe4fd1c83338c0449da5534fdd0